### PR TITLE
[#126] left menu z-index over bottom bar

### DIFF
--- a/www/m/css/styles.css
+++ b/www/m/css/styles.css
@@ -29,6 +29,9 @@ html, body {
 .demo-layout .mdl-layout__header .mdl-layout__drawer-button {
   color: rgba(0, 0, 0, 0.54);
 }
+.mdl-layout__drawer {
+    z-index:105 !important;
+}
 .mdl-layout__drawer .avatar {
   margin-bottom: 16px;
 }


### PR DESCRIPTION
solution for https://github.com/radare/radare2-webui/issues/126

my solution was giving a higher z-index over left-menu so bottom bar doesn't hide it
more or less like the pic:
![captura de pantalla 2017-10-13 a las 13 22 04](https://user-images.githubusercontent.com/423279/31544450-22c2bb00-b01b-11e7-9038-a05db0cae7a5.png)
