### PR TITLE
Variable root location

### DIFF
--- a/www/lib/r2.js
+++ b/www/lib/r2.js
@@ -9,7 +9,7 @@ var next_lastoff = 0;
 var prev_curoff = 0;
 var prev_lastoff = 0;
 var hascmd = false;
-var r2_root = self.location.pathname.split("/").slice(0, -2).join("/");
+const r2_root = self.location.pathname.split('/').slice(0, -2).join('/');
 
 function isFirefoxOS() {
 	if (typeof locationbar !== 'undefined' && !locationbar.visible) {

--- a/www/lib/r2.js
+++ b/www/lib/r2.js
@@ -9,6 +9,7 @@ var next_lastoff = 0;
 var prev_curoff = 0;
 var prev_lastoff = 0;
 var hascmd = false;
+var r2_root = self.location.pathname.split("/").slice(0, -2).join("/");
 
 function isFirefoxOS() {
 	if (typeof locationbar !== 'undefined' && !locationbar.visible) {
@@ -29,7 +30,7 @@ if (isFirefoxOS()) {
 	/* Requires CORS or SystemXHR */
 	r2.root = 'http://cloud.radare.org';
 } else {
-	r2.root = '';
+	r2.root = r2_root;
 }
 
 // async helper
@@ -87,7 +88,7 @@ try {
 	}
 } catch (e) {}
 
-r2.root = ''; // prefix path
+r2.root = r2_root; // prefix path
 
 /* helpers */
 function dump(obj) {

--- a/www/m/workers/disasmNavProvider.js
+++ b/www/m/workers/disasmNavProvider.js
@@ -1,5 +1,7 @@
 'use strict';
-importScripts('/m/r2.js');
+
+var m_root = self.location.pathname.split("/").slice(0, -1).join("/");
+importScripts(m_root + '/r2.js');
 
 var LINES = 80;
 var MAXLINES = Math.round(LINES * 1.20); // +20%

--- a/www/m/workers/disasmNavProvider.js
+++ b/www/m/workers/disasmNavProvider.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var m_root = self.location.pathname.split("/").slice(0, -1).join("/");
+const m_root = self.location.pathname.split('/').slice(0, -1).join('/');
 importScripts(m_root + '/r2.js');
 
 var LINES = 80;

--- a/www/m/workers/disasmProvider.js
+++ b/www/m/workers/disasmProvider.js
@@ -1,5 +1,7 @@
 'use strict';
-importScripts('/m/r2.js');
+
+var m_root = self.location.pathname.split("/").slice(0, -1).join("/");
+importScripts(m_root + '/r2.js');
 
 function extractOffset(str) {
 	var res = str.match(/(0x[a-fA-F0-9]+)/);

--- a/www/m/workers/disasmProvider.js
+++ b/www/m/workers/disasmProvider.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var m_root = self.location.pathname.split("/").slice(0, -1).join("/");
+const m_root = self.location.pathname.split('/').slice(0, -1).join('/');
 importScripts(m_root + '/r2.js');
 
 function extractOffset(str) {

--- a/www/m/workers/hexchunkProvider.js
+++ b/www/m/workers/hexchunkProvider.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var m_root = self.location.pathname.split("/").slice(0, -1).join("/");
+const m_root = self.location.pathname.split('/').slice(0, -1).join('/');
 importScripts(m_root + '/r2.js');
 
 var howManyBytes;

--- a/www/m/workers/hexchunkProvider.js
+++ b/www/m/workers/hexchunkProvider.js
@@ -1,5 +1,7 @@
 'use strict';
-importScripts('/m/r2.js');
+
+var m_root = self.location.pathname.split("/").slice(0, -1).join("/");
+importScripts(m_root + '/r2.js');
 
 var howManyBytes;
 var nbCols;


### PR DESCRIPTION
Added support for variable root location (e.g. `/radare` instead of `/`).

This is achieved by using `self.location.pathname` and stripping the filename (and the view prefix where necessary).